### PR TITLE
Pass a string to scanBlueprints instead of an array

### DIFF
--- a/view.php
+++ b/view.php
@@ -69,8 +69,8 @@ class ViewPlugin extends Plugin
         $locator = Grav::instance()['locator'];
 
         // Set blueprints & templates.
-        $types->scanBlueprints($locator->findResources('plugin://' . $this->name . '/blueprints'));
-        $types->scanTemplates($locator->findResources('plugin://' . $this->name . '/templates'));
+        $types->scanBlueprints($locator->findResource('plugin://' . $this->name . '/blueprints'));
+        $types->scanTemplates($locator->findResource('plugin://' . $this->name . '/templates'));
     }
 
     /**


### PR DESCRIPTION
Hi Elliott, looks like there's an issue caused by the plugin in Admin 1.1, opened here: https://github.com/getgrav/grav-plugin-admin/issues/664

This PR fixes it.
